### PR TITLE
Change to apply pry-rails, better_errors and binding_of_caller gems in only development enviornment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,6 @@ group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 
-  gem 'pry-rails'
-  gem 'better_errors'
-
   gem 'capistrano', '3.6.0'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
@@ -68,6 +65,10 @@ group :development do
 
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
+
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 gem 'rails_admin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,6 +508,7 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   better_errors
+  binding_of_caller
   byebug
   cancan
   capistrano (= 3.6.0)


### PR DESCRIPTION
#2 

・Gemfileにある 'pry-rails', 'better_errors' の記述場所を変更（group :development, :test do 〜 end ループ内から group :development 〜 endループ内へ）
・Gemfileに 'binding_of_caller' の記述を追加（group :development 〜 end ループ内）
